### PR TITLE
implement remember dismiss feature + tests

### DIFF
--- a/src/data/dismissalCookie.ts
+++ b/src/data/dismissalCookie.ts
@@ -1,0 +1,39 @@
+export function useDismissalCookie() {
+    const cookieName = 'smart-app-banner-dismissed';
+
+    function getCookie(name: string) {
+        const cookies: Record<string, string> = {};
+
+        document.cookie.split(';').forEach(kvp => {
+            const [name, value] = kvp.split('=');
+            cookies[name.trim()] = value ?? '';
+        });
+
+        return cookies[name];
+    }
+
+    /**
+     * Update or insert the dismissal cookie
+     *
+     * @param dismissed 1 for true, 0 for false
+     * @param path a URL path that restricts the cookie to the requested URL
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#define_where_cookies_are_sent
+     */
+    function upsertDismissalCookie(dismissed: boolean, path: string) {
+        document.cookie = `${cookieName}=${dismissed ? 1 : 0}; path=${path?.isFalsishOrEmpty() ? '/' : path}`;
+    }
+
+    return {
+        isDismissed: () => getCookie(cookieName) === '1',
+        /**
+         * Dismiss the banner
+         * @param path the path to apply the dismisall to (SPAs should set '/')
+         */
+        dismiss: (path: string) => upsertDismissalCookie(true, path),
+        /**
+         * Reshow the banner
+         * @param path the path to apply the dismisall to (SPAs should set '/')
+         */
+        show: (path: string) => upsertDismissalCookie(false, path),
+    };
+}

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -7,7 +7,8 @@ import type { SmartAppBanner } from '../smartappbanner';
 export type SmartAppBannerEvents =
     | ReadyEvent
     | DestroyedEvent
-    | ClickedCallToAction;
+    | ClickedCallToAction
+    | ToggledVisibility;
 
 /**
  * Base class for all events dispatched by {@link SmartAppBanner}
@@ -47,5 +48,17 @@ export class ClickedCallToAction extends SmartAppBannerEvent {
     /** @internal */
     constructor() {
         super(ClickedCallToAction.type, true);
+    }
+}
+
+/**
+ * @event Triggered when the user clicks the dismiss button or programmatically toggles visiblity, provide an event.
+ */
+export class ToggledVisibility extends SmartAppBannerEvent {
+    static override readonly type = 'toggled-visibility';
+
+    /** @internal */
+    constructor() {
+        super(ToggledVisibility.type, true);
     }
 }

--- a/src/data/options.ts
+++ b/src/data/options.ts
@@ -18,6 +18,7 @@ export const DEFAULT_OPTIONS: Required<
     price: null,
     buttonLabel: 'View',
     verbose: false,
+    dismissPath: '/',
 
     // --------------------------------------------
     // Android Platform Options
@@ -81,6 +82,11 @@ export const OPTION_PARSERS: OptionParsers<
         Logger.debug('verbose logging enabled');
         // we have already asserted that the param is not undefined
         return verbose!;
+    },
+    dismissPath: (dismissPath, { defaultValue }) => {
+        if (dismissPath?.isFalsishOrEmpty()) return defaultValue;
+        // we have already asserted that the param is not undefined
+        return dismissPath!;
     },
     // --------------------------------------------
     // Android Platform Options

--- a/src/dismissal-cookie.spec.ts
+++ b/src/dismissal-cookie.spec.ts
@@ -1,0 +1,75 @@
+import { type SmartAppBanner } from './smartappbanner';
+import { type SmartBannerOptions } from '@models';
+
+vi.mock('@utils/platformUtil', () => ({
+    getCurrentPlatform: vi.fn(),
+}));
+
+vi.mock('@data/options', () => ({
+    getSmartAppBannerOptions: vi.fn(options => options),
+}));
+
+import { getCurrentPlatform } from '@utils/platformUtil';
+
+describe('remember dismissal', () => {
+    let banner: SmartAppBanner;
+    const defaultOptions: SmartBannerOptions = {
+        title: 'Test App',
+        author: 'Test Author',
+        price: '$0.99',
+        androidPrice: '$0.89',
+        applePrice: '$0.99',
+        icon: 'default-icon.png',
+        androidIcon: 'android-icon.png',
+        appleIcon: 'apple-icon.png',
+        buttonLabel: 'Install',
+        androidButtonLabel: 'Get it on Google Play',
+        appleButtonLabel: 'Download on the App Store',
+        googlePlayStoreUrl: 'https://play.google.com',
+        appStoreUrl: 'https://apps.apple.com',
+        verbose: false,
+        dismissPath: '/',
+    };
+
+    const getBanner = () => document.querySelector(`#${banner.bannerId}`);
+
+    beforeEach(async () => {
+        // reset all cookies fresh for every test
+        document.cookie = '';
+
+        document.body.innerHTML = '';
+        (getCurrentPlatform as any).mockReturnValue('android');
+        // dynamically import to ensure mocking order of operations is as expected
+        const { SmartAppBanner } = await import('./smartappbanner');
+        banner = new SmartAppBanner(defaultOptions);
+    });
+
+    afterEach(() => {
+        banner.destroy();
+        document.body.innerHTML = '';
+    });
+
+    test('should stay dismissed one closed', () => {
+        banner.mount();
+        // no cookie should be set yet, as we freshly mounted
+        expect(document.cookie).toBe('');
+
+        // close the banner, the cookie should now be set
+        const event = new Event('click');
+        banner.onClickClose(event);
+        expect(document.cookie).toContain('smart-app-banner-dismissed=1');
+
+        // banner should have been removed now
+        expect(getBanner()?.innerHTML).toBeUndefined();
+        // attempt to remount (ie. "refresh")
+        banner.mount();
+        // banner should still not exist
+        expect(getBanner()?.innerHTML).toBeUndefined();
+    });
+
+    test('should not mount given existing cookie', () => {
+        document.cookie = 'smart-app-banner-dismissed=1';
+        banner.mount();
+        expect(getBanner()?.innerHTML).toBeUndefined();
+    });
+});

--- a/src/models.ts
+++ b/src/models.ts
@@ -43,6 +43,16 @@ export type SmartBannerOptions = {
      */
     verbose?: boolean;
 
+    /**
+     * The path to hide the banner on once its dismissed. This allows conditionally rendering the banner
+     * on specific paths.
+     *
+     * SPA's should set '/' to apply hide/show the banner as expected (default behaviour)
+     *
+     * @default /
+     */
+    dismissPath?: string;
+
     // --------------------------------------------
     // Android Platform Options
 
@@ -120,6 +130,7 @@ export type ParsedSmartBannerOptions = {
     price: string | null;
     buttonLabel: string;
     verbose: boolean;
+    dismissPath: string;
 
     // --------------------------------------------
     // Android Platform Options

--- a/src/smartappbanner.spec.ts
+++ b/src/smartappbanner.spec.ts
@@ -1,5 +1,5 @@
 import { type SmartAppBanner } from './smartappbanner';
-import { SmartAppBannerError } from '@models';
+import { SmartAppBannerError, type SmartBannerOptions } from '@models';
 
 vi.mock('@utils/platformUtil', () => ({
     getCurrentPlatform: vi.fn(),
@@ -13,7 +13,7 @@ import { getCurrentPlatform } from '@utils/platformUtil';
 
 describe('SmartAppBanner', () => {
     let banner: SmartAppBanner;
-    const defaultOptions = {
+    const defaultOptions: SmartBannerOptions = {
         title: 'Test App',
         author: 'Test Author',
         price: '$0.99',
@@ -28,6 +28,7 @@ describe('SmartAppBanner', () => {
         googlePlayStoreUrl: 'https://play.google.com',
         appStoreUrl: 'https://apps.apple.com',
         verbose: false,
+        dismissPath: '/',
     };
 
     const getBanner = () => document.querySelector(`#${banner.bannerId}`);


### PR DESCRIPTION
# Implements

* new option for dismissal path
* cookie to hide the banner if it's already dismissed

# Tests

![image](https://github.com/user-attachments/assets/33c21b86-9e78-4f62-b780-3967f9286b56)
