### PR TITLE
Feature/remove safari support

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,7 +8,9 @@ An Easy Smart App Banner for promoting mobile app installs based on the Safari A
 > [!NOTE]
 > This isn't for everyone. Most people should probably prefer the [PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) approach. However, if you need a 'simple' banner that redirects to a _native_ mobile app then keep reading.
 >
-> For specific details on iOS and Safari specifically, read [here](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners) and for Android see [here](https://developer.chrome.com/blog/app-install-banners-native/).
+> For Safari support see [Safari Support](#safari-support).
+> For specific details on iOS and Safari, read [here](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners).
+> Likewise for Android see [here](https://developer.chrome.com/blog/app-install-banners-native/).
 
 <img src='https://github.com/user-attachments/assets/de1387da-e51a-4851-9a64-345dbf0349ce' style='width: 69%;' />
 
@@ -19,7 +21,7 @@ An Easy Smart App Banner for promoting mobile app installs based on the Safari A
 - Small! `16.60 kB │ gzip: 4.82 kB │ map: 55.09 kB`
 - Platform specific
   - custom banner for iOS (non-Safari) and Android user agents
-  - Safari specific config
+  - ~~Safari specific config~~ See [Safari Support](#safari-support)
 - Option, use SCSS/Sass variables to configure the banner as needed
 - Cookie-based dismissal, dismiss once per browser
 
@@ -34,6 +36,10 @@ npm i -S @easy-smart-app-banner/core
 ## Configuration
 
 <https://github.com/albert118/smart-app-banner/blob/a3b0ec2a68090d45c64b79c2c92f09204f87bf05/src/models.ts#L1-L110>
+
+## Safari Support
+
+This libary currently excludes Safari, as it is not possible to support Safari via a library/plugin/etc. Support for the native Safari smart app banner MUST be provided via static meta tags in your site directly. Safari currently only supports parsing this metadata immediately on page load and will not parse any metadata added after this point. If you want to natively include the Safari banner, then read on [here](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners).
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Easy Smart App Banner
 
 [![NPM version](https://img.shields.io/npm/v/smart-app-banner?color=e3e023&label=%22Easy%20Smart%20App%20Banner%22)](https://www.npmjs.com/package/@easy-smart-app-banner/core) [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
-
 An Easy Smart App Banner for promoting mobile app installs based on the Safari Apple Experience.
 
 > This isn't for everyone. Most people should probably prefer the [PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) approach. However, if you need a 'simple' banner that redirects to a _native_ mobile app then keep reading.
 >
-> For specific details on iOS and Safari specifically, read [here](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners) and for Android see [here](https://developer.chrome.com/blog/app-install-banners-native/).
+> For Safari support see [Safari Support](#safari-support).
+> For specific details on iOS and Safari, read [here](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners).
+> Likewise for Android see [here](https://developer.chrome.com/blog/app-install-banners-native/).
 
 <img src='https://github.com/user-attachments/assets/de1387da-e51a-4851-9a64-345dbf0349ce' style='width: 69%;' />
 
@@ -17,7 +18,7 @@ An Easy Smart App Banner for promoting mobile app installs based on the Safari A
 - Small! `16.74 kB │ gzip: 4.83 kB │ map: 55.62 kB`
 - Platform specific
   - custom banner for iOS (non-Safari) and Android user agents
-  - Safari specific config
+  - ~~Safari specific config~~ See [Safari Support](#safari-support)
 - Option, use SCSS/Sass variables to configure the banner as needed
 - Cookie-based dismissal, dismiss once per browser
 
@@ -32,6 +33,10 @@ npm i -S @easy-smart-app-banner/core
 ## Configuration
 
 See [here](https://github.com/albert118/smart-app-banner/blob/a3b0ec2a68090d45c64b79c2c92f09204f87bf05/src/models.ts#L1-L110)
+
+## Safari Support
+
+This libary currently excludes Safari, as it is not possible to support Safari via a library/plugin/etc. Support for the native Safari smart app banner MUST be provided via static meta tags in your site directly. Safari currently only supports parsing this metadata immediately on page load and will not parse any metadata added after this point. If you want to natively include the Safari banner, then read on [here](https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners).
 
 ## Advanced Usage
 

--- a/src/data/options.spec.ts
+++ b/src/data/options.spec.ts
@@ -174,47 +174,6 @@ describe('options', () => {
             }),
         ).toEqual(new URL(url));
     });
-
-    test('throws if appleAppId is falsish with safari platform', () => {
-        expect(() =>
-            OPTION_PARSERS.appleAppId('', {
-                defaultValue: null,
-                // @ts-ignore
-                rawOptions: { platforms: ['safari'] },
-            }),
-        ).toThrow(SmartAppBannerError);
-    });
-
-    test('returns valid appleAppId', () => {
-        expect(
-            OPTION_PARSERS.appleAppId('12345', {
-                defaultValue: null,
-                // @ts-ignore
-                rawOptions: { platforms: ['safari'] },
-            }),
-        ).toBe('12345');
-    });
-
-    test('throws if appleAppArgumentUrl is invalid', () => {
-        expect(() =>
-            OPTION_PARSERS.appleAppArgumentUrl('bad-url', {
-                defaultValue: null,
-                // @ts-ignore
-                rawOptions: { platforms: ['safari'] },
-            }),
-        ).toThrow(SmartAppBannerError);
-    });
-
-    test('returns valid appleAppArgumentUrl', () => {
-        const url = 'https://example.com';
-        expect(
-            OPTION_PARSERS.appleAppArgumentUrl(url, {
-                defaultValue: null,
-                // @ts-ignore
-                rawOptions: { platforms: ['safari'] },
-            }),
-        ).toEqual(new URL(url));
-    });
 });
 
 describe('getSmartAppBannerOptions', () => {
@@ -264,10 +223,6 @@ describe('getSmartAppBannerOptions', () => {
         expect(result.appleIcon).toBeNull();
         expect(result.appleButtonLabel).toBeNull();
         expect(result.applePrice).toBe('GET - On the App Store');
-
-        // Safari options should be disabled
-        expect(result.appleAppId).toBeNull();
-        expect(result.appleAppArgumentUrl).toBeNull();
     });
 
     test('parses known options correctly for Apple', () => {
@@ -279,8 +234,6 @@ describe('getSmartAppBannerOptions', () => {
             price: '$1.99',
             buttonLabel: 'Get test',
             appStoreUrl: 'https://apps.apple.com',
-            appleAppId: '12345',
-            appleAppArgumentUrl: 'https://example.com',
             appleIcon: 'apple-icon.png',
             appleButtonLabel: 'Download',
             applePrice: 'Free',
@@ -304,10 +257,6 @@ describe('getSmartAppBannerOptions', () => {
         expect(result.appleIcon).toBe('apple-icon.png');
         expect(result.appleButtonLabel).toBe('Download');
         expect(result.applePrice).toBe('Free');
-
-        // Safari options should be disabled
-        expect(result.appleAppId).toBeNull();
-        expect(result.appleAppArgumentUrl).toBeNull();
     });
 
     test('parses known options correctly for Safari', () => {
@@ -318,8 +267,6 @@ describe('getSmartAppBannerOptions', () => {
             platforms: ['safari'],
             price: '$99.99',
             buttonLabel: 'Get tested',
-            appleAppId: '12345',
-            appleAppArgumentUrl: 'https://example.com',
         };
 
         const result = getSmartAppBannerOptions(options);
@@ -340,11 +287,5 @@ describe('getSmartAppBannerOptions', () => {
         expect(result.appleIcon).toBeNull();
         expect(result.appleButtonLabel).toBeNull();
         expect(result.applePrice).toBe('GET - On the App Store');
-
-        // Safari options should be disabled
-        expect(result.appleAppId).toBe('12345');
-        expect(result.appleAppArgumentUrl).toEqual(
-            new URL('https://example.com'),
-        );
     });
 });

--- a/src/data/options.ts
+++ b/src/data/options.ts
@@ -30,8 +30,6 @@ export const DEFAULT_OPTIONS: Required<
     // --------------------------------------------
     // Apple Platform Options
     appStoreUrl: null,
-    appleAppId: null,
-    appleAppArgumentUrl: null,
     appleButtonLabel: null,
     appleIcon: null,
     applePrice: 'GET - On the App Store',
@@ -141,32 +139,6 @@ export const OPTION_PARSERS: OptionParsers<
             return new URL(appStoreUrl!);
         } catch (error) {
             throw new SmartAppBannerError(reason);
-        }
-    },
-    appleAppId: (appleAppId, { rawOptions }) => {
-        if (!rawOptions.platforms?.includes('safari')) return null;
-
-        if (appleAppId?.isFalsishOrEmpty()) {
-            throw new SmartAppBannerError(
-                `The Safari platform was enabled but no valid Apple app ID has been configured. Provided app ID was "${appleAppId}"`,
-            );
-        }
-
-        // we have already asserted that the param is not undefined
-        return appleAppId!;
-    },
-    appleAppArgumentUrl: (appleAppArgumentUrl, { rawOptions }) => {
-        if (!rawOptions.platforms?.includes('safari')) return null;
-        // this param is optional, if it wasn't specified this is still valid
-        if (appleAppArgumentUrl?.isFalsishOrEmpty()) return null;
-
-        try {
-            // we have already asserted that the param is not undefined
-            return new URL(appleAppArgumentUrl!);
-        } catch (error) {
-            throw new SmartAppBannerError(
-                `The Safari platform was enabled but an invalid app argument URL was specified. Provided app argument URL was "${appleAppArgumentUrl}"`,
-            );
         }
     },
     appleButtonLabel: (appleButtonLabel, { rawOptions }) => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,8 @@
-export type SupportedPlatForm = 'android' | 'ios' | 'safari';
+// indirectly used for type assertions during option building (ie. "is this option relevant to platform 'X'?")
+export type SupportedPlatForm = 'android' | 'ios';
+
+// we maintain Safari here to allow checks to skip the platform
+export type ParsedPlatform = 'android' | 'ios' | 'safari';
 
 export type SmartBannerOptions = {
     title: string;
@@ -12,9 +16,6 @@ export type SmartBannerOptions = {
 
     /**
      * Enabled platforms. If a platform is enabled here it must be configured.
-     *
-     * If 'safari' is included, then the native Safari banner will be enabled and require additional configuration.
-     * Ensure that the appleAppId and (optionally) the appleAppArgumentUrl.
      *
      * @see https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners
      * @default ['android', 'ios']

--- a/src/models.ts
+++ b/src/models.ts
@@ -89,20 +89,6 @@ export type SmartBannerOptions = {
     appStoreUrl?: string;
 
     /**
-     * Sets the Apple app store ID. This IS required if enableSafariSupport is true
-     *
-     * @see https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners
-     */
-    appleAppId?: string;
-
-    /**
-     * Sets the argument URL parsed to Safari browsers.
-     *
-     * @see https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners#Provide-Navigational-Context-to-Your-App
-     */
-    appleAppArgumentUrl?: string;
-
-    /**
      * Apple specific button label. If not specified, falls back to buttonLabel.
      */
     appleButtonLabel?: string;
@@ -142,8 +128,6 @@ export type ParsedSmartBannerOptions = {
     // --------------------------------------------
     // Apple Platform Options
     appStoreUrl: URL | null;
-    appleAppId: string | null;
-    appleAppArgumentUrl: URL | null;
     appleButtonLabel: string | null;
     appleIcon: string | null;
     applePrice: string;

--- a/src/smartappbanner.spec.ts
+++ b/src/smartappbanner.spec.ts
@@ -161,7 +161,7 @@ describe('SmartAppBanner', () => {
             expect(document.querySelector(banner.bannerId)).toBeNull();
         });
 
-        test('should add Safari meta tag', async () => {
+        test('should NOT add Safari meta tag', async () => {
             (getCurrentPlatform as any).mockReturnValue('safari');
             // dynamically import to ensure mocking order of operations is as expected
             const { SmartAppBanner } = await import('./smartappbanner');
@@ -180,10 +180,8 @@ describe('SmartAppBanner', () => {
                 ...document.head.querySelectorAll('meta'),
             ].find(meta => meta.name === 'apple-itunes-app');
 
-            expect(safariMetaTag).toBeDefined();
-            expect(safariMetaTag!.content).toMatch(
-                `app-id=${safariOptions.appleAppId}, app-argument=${safariOptions.appleAppArgumentUrl}`,
-            );
+            // because we cannot support Safari meta tags using a plugin/library, this metadata must be present immediately on page load
+            expect(safariMetaTag).not.toBeDefined();
         });
 
         test('should throw an error when attempting to resolve HTML for Safari', async () => {

--- a/src/smartappbanner.ts
+++ b/src/smartappbanner.ts
@@ -11,7 +11,7 @@ import {
     SmartAppBannerError,
     type ParsedSmartBannerOptions,
     type SmartBannerOptions,
-    type SupportedPlatForm,
+    type ParsedPlatform,
 } from '@models';
 import { getCurrentPlatform } from '@utils/platformUtil';
 import Logger from 'js-logger';
@@ -24,7 +24,7 @@ export class SmartAppBanner extends TypedEventTarget<SmartAppBannerEvents> {
      * If the platform is undefined, then it is not a supported platform.
      * eg. a desktop environment (as this is intended for mobile)
      */
-    readonly platform: SupportedPlatForm | undefined;
+    readonly platform: ParsedPlatform | undefined;
     readonly bannerId = 'smart-app-banner';
     private __bannerElement: HTMLElement | null = null;
 

--- a/src/smartappbanner.ts
+++ b/src/smartappbanner.ts
@@ -46,12 +46,9 @@ export class SmartAppBanner extends TypedEventTarget<SmartAppBannerEvents> {
     mount() {
         if (!this.platform) return;
 
-        // handle Safari separately and avoid creating a component
+        // Safari will only recognise the relevant config if it is present immediately on page load - it cannot be handled by a plugin/library
         // https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners
-        if (this.platform === 'safari') {
-            this.setUpSafari();
-            return;
-        }
+        if (this.platform === 'safari') return;
 
         const dismissalCookie = useDismissalCookie();
         if (dismissalCookie.isDismissed()) return;
@@ -79,15 +76,6 @@ export class SmartAppBanner extends TypedEventTarget<SmartAppBannerEvents> {
         Logger.debug('mounted banner');
         Logger.timeEnd('mounting banner');
         this.dispatchEvent(new ReadyEvent());
-    }
-
-    // You can’t display Smart App Banners inside a frame. Banners don’t appear in the iOS simulator.
-    setUpSafari() {
-        const metaTag = document.createElement('meta');
-        metaTag.name = 'apple-itunes-app';
-        metaTag.content = `app-id=${this.options.appleAppId}, app-argument=${this.options.appleAppArgumentUrl}`;
-        document.head.append(metaTag);
-        Logger.debug('added Safari configuration');
     }
 
     destroy() {

--- a/src/utils/platformUtil.ts
+++ b/src/utils/platformUtil.ts
@@ -1,13 +1,13 @@
-import { type SupportedPlatForm } from '@models';
+import { type ParsedPlatform } from '@models';
 import Logger from 'js-logger';
 
 // a good demo site for testing assumptions
 // http://detectmobilebrowsers.com/
 // a Gist "blog" on device detection
 // https://gist.github.com/dalethedeveloper/1503252
-export function getCurrentPlatform(): SupportedPlatForm | undefined {
+export function getCurrentPlatform(): ParsedPlatform | undefined {
     const userAgent = window.navigator.userAgent;
-    let currentPlatform: SupportedPlatForm | undefined = undefined;
+    let currentPlatform: ParsedPlatform | undefined = undefined;
 
     Logger.debug('Current user agent: ', userAgent);
 


### PR DESCRIPTION
Removed Safari support,

* added documentation explanation
* this was already effective by simply removing "Safari"
* removed Safari as a supported platform option and removed the related config for it