### PR TITLE
updated package-lock.json manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "2.1.1",
             "license": "MIT",
             "dependencies": {
-                "js-logger": "^1.6.1"
+                "js-logger": "^1.6.1",
+                "typescript": "^5.9.2"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.7",


### PR DESCRIPTION
Fixup the `package-lock.json`. Dependabot disagrees with `npm` on this one.

_tests still passing ofc_

<img width="1265" height="462" alt="image" src="https://github.com/user-attachments/assets/c74bd61d-c184-4f68-b543-e1aa68e166de" />
